### PR TITLE
Fix 1-wire comment: EIO0, not EIO8

### DIFF
--- a/Examples/More/1-Wire/1_wire.py
+++ b/Examples/More/1-Wire/1_wire.py
@@ -6,7 +6,7 @@ demonstration:
   - Reads temperature from a DS1822 sensor.
 
 Relevant Documentation:
- 
+
 LJM Library:
     LJM Library Installer
         https://labjack.com/support/software/installers/ljm
@@ -16,7 +16,7 @@ LJM Library:
         https://labjack.com/support/software/api/ljm/function-reference/opening-and-closing
     Multiple Value Functions(such as eReadNames):
         https://labjack.com/support/software/api/ljm/function-reference/multiple-value-functions
- 
+
 T-Series and I/O:
     1-Wire:
         https://labjack.com/support/datasheets/t-series/digital-io/1-wire
@@ -49,7 +49,7 @@ if deviceType == ljm.constants.dtT4:
 
 
 # Configure 1-Wire pins and options.
-dqPin = 8  # EIO8
+dqPin = 8  # EIO0
 dpuPin = 0  # Not used
 options = 0  # bit 2 = 0 (DPU disabled), bit 3 = 0 (DPU polarity low, ignored)
 aNames = ["ONEWIRE_DQ_DIONUM",


### PR DESCRIPTION
The 1-wire.py example works great, but has a confusing typo inside it:  A comment refers to EIO8 as the 1-wire data pin, rather than the correct (and referenced elsewhere, e.g. line 5) EIO0.  This fixes that comment.