### PR TITLE
Remove top-level error handling in _loadLibrary

### DIFF
--- a/labjack/ljm/ljm.py
+++ b/labjack/ljm/ljm.py
@@ -81,41 +81,36 @@ class LJMError(Exception):
 
 def _loadLibrary():
     """Returns a ctypes pointer to the LJM library."""
+    libraryName = None
     try:
-        libraryName = None
-        try:
-            if(sys.platform.startswith("win32") or sys.platform.startswith("cygwin")):
-                # Windows
-                libraryName = "LabJackM.dll"
-            if(sys.platform.startswith("linux")):
-                # Linux
-                libraryName = "libLabJackM.so"
-            if(sys.platform.startswith("darwin")):
-                # Mac OS X
-                libraryName = "libLabJackM.dylib"
+        if(sys.platform.startswith("win32") or sys.platform.startswith("cygwin")):
+            # Windows
+            libraryName = "LabJackM.dll"
+        if(sys.platform.startswith("linux")):
+            # Linux
+            libraryName = "libLabJackM.so"
+        if(sys.platform.startswith("darwin")):
+            # Mac OS X
+            libraryName = "libLabJackM.dylib"
 
-            if libraryName is not None:
-                if libraryName == "LabJackM.dll" and sys.platform.startswith("win32"):
-                    return ctypes.WinDLL(libraryName)
-                else:
-                    return ctypes.CDLL(libraryName)
-        except Exception:
-            if(sys.platform.startswith("darwin")):
-                # Mac OS X load failed. Try with absolute path.
-                try:
-                    libraryName = "/usr/local/lib/libLabJackM.dylib"
-                    return ctypes.CDLL(libraryName)
-                except Exception:
-                    pass
-            e = sys.exc_info()[1]
-            raise LJMError(errorString="Cannot load the LJM library "+str(libraryName)+". "+str(e))
+        if libraryName is not None:
+            if libraryName == "LabJackM.dll" and sys.platform.startswith("win32"):
+                return ctypes.WinDLL(libraryName)
+            else:
+                return ctypes.CDLL(libraryName)
+    except Exception:
+        if(sys.platform.startswith("darwin")):
+            # Mac OS X load failed. Try with absolute path.
+            try:
+                libraryName = "/usr/local/lib/libLabJackM.dylib"
+                return ctypes.CDLL(libraryName)
+            except Exception:
+                pass
+        e = sys.exc_info()[1]
+        raise LJMError(errorString="Cannot load the LJM library "+str(libraryName)+". "+str(e))
 
-        # Unsupported operating system
-        raise LJMError(errorString="Cannot load the LJM library. Unsupported platform "+sys.platform+".")
-    except LJMError:
-        ljme = sys.exc_info()[1]
-        print(str(type(ljme)) + ": " + str(ljme))
-        return None
+    # Unsupported operating system
+    raise LJMError(errorString="Cannot load the LJM library. Unsupported platform "+sys.platform+".")
 
 
 _staticLib = _loadLibrary()


### PR DESCRIPTION
Removing this try block enables LJM loading errors to be percolated up to the user and allows proper handling of them in a reasonable context.  As of now, the program will continue and the import error will be printed to `stdout`.  In some logging contexts these errors won't be seen and won't stop the program, giving a more cryptic error about the library `None` having no attribute `openS`.  To detect the error right now, we would need to do something like
```python
from contextlib import redirect_stdout

with redirect_stdout(None):
    from labjack import ljm
```
which is fairly intuitive.Instead, this update allows users to choose how to handle the error within standard Python error handling (and choosing to ignore as the current version does):
```python
try:
    from labjack import ljm
except LJMError as err:
    # handle error in python
```

I believe the `labjack` module should give users the most options to handle errors as they see fit and not require hacky solutions such as redirecting `stdout` to provide end-users proper error messages in a standard location.